### PR TITLE
feat: Display negative leftover values in red

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,6 +140,40 @@ func main() {
 	table.Append([]string{"sum of all container", fmt.Sprintf("%d", allCPU), fmt.Sprintf("%d", allMemory), fmt.Sprintf("%d", allMemoryReservation)})
 	taskCPU, _ := strconv.ParseInt(taskDefinition.CPU, 10, 64)
 	taskMemory, _ := strconv.ParseInt(taskDefinition.Memory, 10, 64)
-	table.SetFooter([]string{"leftover", fmt.Sprintf("%d", taskCPU-allCPU), fmt.Sprintf("%d", taskMemory-allMemory), fmt.Sprintf("%d", taskMemory-allMemoryReservation)})
+
+	leftoverCPU := taskCPU - allCPU
+	leftoverMemory := taskMemory - allMemory
+	leftoverMemoryReservation := taskMemory - allMemoryReservation
+
+	footerStrings := []string{
+		"leftover",
+		fmt.Sprintf("%d", leftoverCPU),
+		fmt.Sprintf("%d", leftoverMemory),
+		fmt.Sprintf("%d", leftoverMemoryReservation),
+	}
+	table.SetFooter(footerStrings)
+
+	footerColors := make([]tablewriter.Colors, 4)
+	footerColors[0] = tablewriter.Colors{} // For "leftover" label
+
+	if leftoverCPU < 0 {
+		footerColors[1] = tablewriter.Colors{tablewriter.FgRedColor}
+	} else {
+		footerColors[1] = tablewriter.Colors{}
+	}
+
+	if leftoverMemory < 0 {
+		footerColors[2] = tablewriter.Colors{tablewriter.FgRedColor}
+	} else {
+		footerColors[2] = tablewriter.Colors{}
+	}
+
+	if leftoverMemoryReservation < 0 {
+		footerColors[3] = tablewriter.Colors{tablewriter.FgRedColor}
+	} else {
+		footerColors[3] = tablewriter.Colors{}
+	}
+	table.SetFooterColor(footerColors...)
+
 	table.Render()
 }

--- a/test_task.json
+++ b/test_task.json
@@ -1,0 +1,53 @@
+{
+  "taskDefinition": {
+    "family": "test-family",
+    "cpu": "1024",
+    "memory": "2048",
+    "networkMode": "awsvpc",
+    "requiresCompatibilities": [
+      "FARGATE"
+    ],
+    "executionRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+    "containerDefinitions": [
+      {
+        "name": "container1",
+        "image": "nginx:latest",
+        "cpu": 600,
+        "memory": 1500,
+        "memoryReservation": 1024,
+        "essential": true,
+        "portMappings": [
+          {
+            "containerPort": 80,
+            "hostPort": 80,
+            "protocol": "tcp"
+          }
+        ],
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/ecs/test-family",
+            "awslogs-region": "us-east-1",
+            "awslogs-stream-prefix": "ecs"
+          }
+        }
+      },
+      {
+        "name": "container2",
+        "image": "redis:latest",
+        "cpu": 600,
+        "memory": 1500,
+        "memoryReservation": 1024,
+        "essential": true,
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/ecs/test-family",
+            "awslogs-region": "us-east-1",
+            "awslogs-stream-prefix": "ecs"
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I modified the table output to use red color for negative values in the 'LEFTOVER' row of the resources summary.

This enhances readability by quickly highlighting resource deficits. The `tablewriter` library's `SetFooterColor` feature is used to apply conditional coloring to the CPU, Memory, and MemoryReservation columns in the footer.

Unused dependencies were tidied up using `go mod tidy`.